### PR TITLE
enforce valid messages

### DIFF
--- a/app/device/radio.py
+++ b/app/device/radio.py
@@ -4,8 +4,15 @@ import logging
 import json
 
 class Radio(object):
+    ACTION_WAKE='wake'
+    ACTION_SLEEP='sleep'
+    ACTION_LAUNCH='launch'
+    ACTION_TEST_BRAKES='test_brakes'
+    ACTION_POSITION_REPORT='position_report'
+
+    VALID_ACTIONS=[ACTION_WAKE, ACTION_SLEEP, ACTION_LAUNCH, ACTION_TEST_BRAKES, ACTION_POSITION_REPORT]
+
     def __init__(self,baud=9600, port='/dev/ttyUSB0'):
-    # def __init__(self,baud=9600, port='COM3'):
         try:
             self.serial = serial.Serial(port,baud,timeout=1)
             logging.info("Radio Initialized")
@@ -24,11 +31,12 @@ class Radio(object):
     def receive(self):
         try:
             message = self.serial.readline()
-            if message == '':
-                return None
+            logging.info('Radio received message: {}'.format(message))
+            message = json.loads(message) # unicode string
+            if message['action'] in Radio.VALID_ACTIONS:
+                return message
             else:
-                logging.info('Radio received message: {}'.format(message))
-                return json.loads(message) # unicode string
+                raise Expection('Invalid message')
         except Exception as e:
             logging.error('error: {}'.format(e))
             return None

--- a/app/main.py
+++ b/app/main.py
@@ -87,8 +87,8 @@ class Rocket(Thread):
         if time.time() - self.state_data['last_radio_poll'] >= RADIO_POLLING_RATE:
             self.device_factory.radio.wake()
             time.sleep(RADIO_POLL_DURATION)
-            action = self.device_factory.radio.receive()['action']
-            if action == 'wake':
+            message = self.device_factory.radio.receive()
+            if message['action'] is self.device_factory.radio.ACTION_WAKE:
                 self.wake()
             else:
                 self.state_data['last_radio_poll'] = time.time()
@@ -101,11 +101,11 @@ class Rocket(Thread):
     def during_ground(self):
         LAUNCH_ACCELERATION_THRESHOLD = 1.5 # m/s^2
         message = self.device_factory.radio.receive()
-        if message['action'] == u'launch' or self.kinetics.acceleration()['z'] > LAUNCH_ACCELERATION_THRESHOLD:
+        if message['action'] is self.device_factory.radio.ACTION_LAUNCH or self.kinetics.acceleration()['z'] > LAUNCH_ACCELERATION_THRESHOLD:
             self.launch()
-        elif message['action'] == u'sleep':
+        elif message['action'] is self.device_factory.radio.ACTION_SLEEP:
             self.sleep()
-        elif message['action'] == u'test_brakes':
+        elif message['action'] is self.device_factory.radio.ACTION_TEST_BRAKES:
             self.device_factory.brakes.sweep()
 
     def during_powered(self):

--- a/test/device/test_radio.py
+++ b/test/device/test_radio.py
@@ -1,0 +1,67 @@
+import pytest
+
+import json
+from app.device.radio import Radio
+from test.fixtures.dummy_serial import DummySerial
+
+def test_ignores_invalid_messages():
+    invalid_message = {'action': 'NOT A VALID ACTION', 'data': []}
+    radio = Radio()
+    radio.serial = DummySerial(json.dumps(invalid_message))
+
+    assert radio.receive() == None
+
+def test_valid_actions_contain_no_duplicates():
+    radio = Radio()
+    assert len(radio.VALID_ACTIONS) is len(set(radio.VALID_ACTIONS))
+
+def test_captures_wake_message():
+    expected_message = {'action': Radio.ACTION_WAKE, 'data': []}
+    radio = Radio()
+    radio.serial = DummySerial(json.dumps(expected_message))
+
+    message = radio.receive()
+
+    assert message['action'] == expected_message['action']
+    assert message['data'] == expected_message['data']
+
+def test_captures_sleep_message():
+    expected_message = {'action': Radio.ACTION_SLEEP, 'data': []}
+    radio = Radio()
+    radio.serial = DummySerial(json.dumps(expected_message))
+
+    message = radio.receive()
+
+    assert message['action'] == expected_message['action']
+    assert message['data'] == expected_message['data']
+
+def test_captures_launch_message():
+    expected_message = {'action': Radio.ACTION_LAUNCH, 'data': []}
+    radio = Radio()
+    radio.serial = DummySerial(json.dumps(expected_message))
+
+    message = radio.receive()
+
+    assert message['action'] == expected_message['action']
+    assert message['data'] == expected_message['data']
+
+
+def test_captures_test_brake_message():
+    expected_message = {'action': Radio.ACTION_TEST_BRAKES, 'data': []}
+    radio = Radio()
+    radio.serial = DummySerial(json.dumps(expected_message))
+
+    message = radio.receive()
+
+    assert message['action'] == expected_message['action']
+    assert message['data'] == expected_message['data']
+
+def test_captures_test_report_position_message():
+    expected_message = {'action': Radio.ACTION_POSITION_REPORT, 'data': []}
+    radio = Radio()
+    radio.serial = DummySerial(json.dumps(expected_message))
+
+    message = radio.receive()
+
+    assert message['action'] == expected_message['action']
+    assert message['data'] == expected_message['data']

--- a/test/fixtures/dummy_device_factory.py
+++ b/test/fixtures/dummy_device_factory.py
@@ -51,6 +51,12 @@ class DummyAltimeter(object):
 
 
 class DummyRadio(object):
+    ACTION_WAKE='wake'
+    ACTION_SLEEP='sleep'
+    ACTION_LAUNCH='launch'
+    ACTION_TEST_BRAKES='test_brakes'
+    ACTION_POSITION_REPORT='position_report'
+
     def __init__(self):
         self.sleeping = False
         self.action = None

--- a/test/fixtures/dummy_serial.py
+++ b/test/fixtures/dummy_serial.py
@@ -1,0 +1,6 @@
+class DummySerial(object):
+    def __init__(self, read_value):
+        self.read_value = read_value
+
+    def readline(self):
+        return self.read_value


### PR DESCRIPTION
This adds rules to only ingest valid messages.

Also we now have a set of constants that can be used thought the rest of the app to ensure our action keys are consistent..both the client and rocket will share this class so we ensure only valid messages are produced and consumed